### PR TITLE
Update docker/build-push-action to 6.13.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
         restore-keys: ${{ inputs.from_cache > 0 && '' || format('{0}-buildx-', runner.os) }}
         fail-on-cache-miss: ${{ inputs.from_cache > 0 && true || false }}
     - name: Build Docker image
-      uses: docker/build-push-action@4f7cdeb0f05278b464e71357394bf2c61f94138e # 6.6.0
+      uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # 6.13.0
       with:
         push: ${{ inputs.push > 0 && true || false }}
         load: ${{ inputs.from_cache > 0 && false || true }}


### PR DESCRIPTION
Updates docker/build-push-action dependency to v. 6.13.0, released on 2025-01-24.