### PR TITLE
Update docker/setup-buildx-action to 3.10.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
       run: exit 1
       shell: sh
     - name: Set up Docker BuildX
-      uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # 3.6.1
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # 3.10.0
     - name: Set up cache
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # 4.2.0
       with:


### PR DESCRIPTION
Updates the docker/setup-buildx-action dependency to v. 3.10.0, released on 2025-02-26.