### PR TITLE
Update actions/cache to 4.2.3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ runs:
     - name: Set up Docker BuildX
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # 3.10.0
     - name: Set up cache
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # 4.2.0
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}


### PR DESCRIPTION
Updates the actions/cache dependency to v. 4.2.3, released on 2025-03-26.