### PR TITLE
Update docker/setup-buildx-action to 3.11.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
       run: exit 1
       shell: sh
     - name: Set up Docker BuildX
-      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # 3.10.0
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # 3.11.1
     - name: Set up cache
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
       with:


### PR DESCRIPTION
Updates the docker/setup-buildx-action to v. 3.11.1, released on 2025-06-18.