### PR TITLE
Update docker/build-push-action to 6.18.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
         restore-keys: ${{ inputs.from_cache > 0 && '' || format('{0}-buildx-', runner.os) }}
         fail-on-cache-miss: ${{ inputs.from_cache > 0 && true || false }}
     - name: Build Docker image
-      uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # 6.15.0
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # 6.18.0
       with:
         push: ${{ inputs.push > 0 && true || false }}
         load: ${{ inputs.from_cache > 0 && false || true }}


### PR DESCRIPTION
Updates the docker/build-push-action to v. 6.18.0, released on 2025-05-27.